### PR TITLE
Enable meson release build optimizations (-O3).

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('removegrain', 'cpp',
   version : '1',
-  default_options : ['warning_level=3'])
+  default_options : ['warning_level=3', 'buildtype=release', 'b_ndebug=if-release'])
 
 add_project_arguments('-ffast-math', language : 'cpp')
 


### PR DESCRIPTION
The default `buildtype` is debug, so we've been running massively under optimized this whole time.

I ran before/after tests using a simple script:
```
import vapoursynth as vs

core = vs.core

clip = core.ffms2.Source('source.mkv')

clip = clip.rgvs.RemoveGrain(mode=2)
clip = clip.rgvs.RemoveGrain(mode=17)
clip = clip.rgvs.RemoveGrain(mode=7)

clip.set_output()
```

Results:
* Source only = 736 fps
* Old build = 100 fps
* New build = 531 fps.

So we're seeing ~5x speed increase.